### PR TITLE
Release bpf-tools v1.6

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ rm -rf out
 mkdir -p out
 pushd out
 
-git clone --single-branch --branch bpf-tools-v1.5 https://github.com/solana-labs/rust.git
+git clone --single-branch --branch bpf-tools-v1.6 https://github.com/solana-labs/rust.git
 echo "$( cd rust && git rev-parse HEAD )  https://github.com/solana-labs/rust.git" >> version.md
 
 git clone --single-branch --branch rust-1.50.0 https://github.com/rust-lang/cargo.git


### PR DESCRIPTION
This release contains LLVM BPF backend that enables Solana extension
by a command line option.  To compile contracts for Solana network use
the clang command line option -march=bpfel+solana. Rust compiler
internally enables Solana extensions and doesn't require new command
line options.