### PR TITLE
Release bpf-tools v1.11

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ rm -rf out
 mkdir -p out
 pushd out
 
-git clone --single-branch --branch bpf-tools-v1.10 https://github.com/solana-labs/rust.git
+git clone --single-branch --branch bpf-tools-v1.11 https://github.com/solana-labs/rust.git
 echo "$( cd rust && git rev-parse HEAD )  https://github.com/solana-labs/rust.git" >> version.md
 
 git clone --single-branch --branch rust-1.52.0 https://github.com/rust-lang/cargo.git


### PR DESCRIPTION
Rust compiler truncates full path strings embedded in .so modules to
prevent revealing usernames.