### PR TITLE
Add Windows build job and build.sh support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,12 @@ jobs:
           ninja_sha: 6fa359f491fac7e5185273c6421a000eea6a2f0febf0ac03ac900bd4d80ed2a5
           rust: stable
           tar: osx
+        - target: x86_64-pc-windows-msvc
+          os: windows-latest
+          ninja_file: ninja-win.zip
+          ninja_sha: bbde850d247d2737c5764c927d1071cbb1f1957dcabda4a130fa8547c12c695f
+          rust: stable
+          tar: windows
     steps:
     - uses: actions/checkout@v1
     - name: Install coreutils
@@ -62,6 +68,10 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: solana-bpf-tools-osx.tar.bz2
+    - name: Download Windows tarball
+      uses: actions/download-artifact@v2
+      with:
+        name: solana-bpf-tools-windows.tar.bz2
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1
@@ -91,4 +101,14 @@ jobs:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
         asset_path: solana-bpf-tools-osx.tar.bz2
         asset_name: solana-bpf-tools-osx.tar.bz2
+        asset_content_type: application/zip
+    - name: Release Windows tarball
+      id: upload-release-windows
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: solana-bpf-tools-windows.tar.bz2
+        asset_name: solana-bpf-tools-windows.tar.bz2
         asset_content_type: application/zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
       shell: bash
     - name: Install Ninja
       run: |
-        wget "https://github.com/ninja-build/ninja/releases/download/v1.10.2/${{ matrix.ninja_file }}" && \
+        curl -L -O "https://github.com/ninja-build/ninja/releases/download/v1.10.2/${{ matrix.ninja_file }}" && \
         echo "${{ matrix.ninja_sha }} ${{ matrix.ninja_file }}" | sha256sum -c && \
         sudo unzip ${{ matrix.ninja_file }} -d /usr/local/bin && rm ${{ matrix.ninja_file }}
       shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,18 +13,24 @@ jobs:
           os: ubuntu-18.04
           ninja_file: ninja-linux.zip
           ninja_sha: 763464859c7ef2ea3a0a10f4df40d2025d3bb9438fcb1228404640410c0ec22d
+          ninja_dir: /usr/local/bin
+          ninja_sudo: sudo
           rust: stable
           tar: linux
         - target: x86_64-apple-darwin
           os: macos-latest
           ninja_file: ninja-mac.zip
           ninja_sha: 6fa359f491fac7e5185273c6421a000eea6a2f0febf0ac03ac900bd4d80ed2a5
+          ninja_dir: /usr/local/bin
+          ninja_sudo: sudo
           rust: stable
           tar: osx
         - target: x86_64-pc-windows-msvc
           os: windows-latest
           ninja_file: ninja-win.zip
           ninja_sha: bbde850d247d2737c5764c927d1071cbb1f1957dcabda4a130fa8547c12c695f
+          ninja_dir: /usr/bin
+          ninja_sudo:
           rust: stable
           tar: windows
     steps:
@@ -38,7 +44,7 @@ jobs:
       run: |
         curl -L -O "https://github.com/ninja-build/ninja/releases/download/v1.10.2/${{ matrix.ninja_file }}" && \
         echo "${{ matrix.ninja_sha }} ${{ matrix.ninja_file }}" | sha256sum -c && \
-        sudo unzip ${{ matrix.ninja_file }} -d /usr/local/bin && rm ${{ matrix.ninja_file }}
+        ${{ matrix.ninja_sudo }} unzip ${{ matrix.ninja_file }} -d ${{ matrix.ninja_dir }} && rm ${{ matrix.ninja_file }}
       shell: bash
     - name: Install Rust
       run: |

--- a/build.sh
+++ b/build.sh
@@ -48,7 +48,7 @@ cp -R rust/build/${HOST_TRIPLE}/stage1/bin deploy/rust/
 mkdir -p deploy/rust/lib/rustlib/
 cp -R rust/build/${HOST_TRIPLE}/stage1/lib/rustlib/${HOST_TRIPLE} deploy/rust/lib/rustlib/
 cp -R rust/build/${HOST_TRIPLE}/stage1/lib/rustlib/bpfel-unknown-unknown deploy/rust/lib/rustlib/
-cp -R cargo/target/release/cargo${EXE_SUFFIX} deploy/rust/bin/
+cp -R cargo/target/release/cargo"${EXE_SUFFIX}" deploy/rust/bin/
 
 # Copy llvm build products
 mkdir -p deploy/llvm/{bin,lib}

--- a/build.sh
+++ b/build.sh
@@ -1,13 +1,25 @@
 #!/usr/bin/env bash
 set -ex
 
-if [ "$(uname)" == "Darwin" ]; then
-    HOST_TRIPLE=x86_64-apple-darwin
-    ARTIFACT=solana-bpf-tools-osx.tar.bz2
-else
-    HOST_TRIPLE=x86_64-unknown-linux-gnu
-    ARTIFACT=solana-bpf-tools-linux.tar.bz2
-fi
+unameOut="$(uname -s)"
+case "${unameOut}" in
+    Linux*)
+        EXE_SUFFIX=
+        HOST_TRIPLE=x86_64-unknown-linux-gnu
+        ARTIFACT=solana-bpf-tools-linux.tar.bz2;;
+    Darwin*)
+        EXE_SUFFIX=
+        HOST_TRIPLE=x86_64-apple-darwin
+        ARTIFACT=solana-bpf-tools-osx.tar.bz2;;
+    MINGW*)
+        EXE_SUFFIX=.exe
+        HOST_TRIPLE=x86_64-pc-windows-msvc
+        ARTIFACT=solana-bpf-tools-windows.tar.bz2;;
+    *)
+        EXE_SUFFIX=
+        HOST_TRIPLE=x86_64-unknown-linux-gnu
+        ARTIFACT=solana-bpf-tools-linux.tar.bz2
+esac
 
 cd "$(dirname "$0")"
 
@@ -15,7 +27,7 @@ rm -rf out
 mkdir -p out
 pushd out
 
-git clone --single-branch --branch bpf-tools-v1.15 https://github.com/solana-labs/rust.git
+git clone --single-branch --branch bpf-tools-v1.16 https://github.com/solana-labs/rust.git
 echo "$( cd rust && git rev-parse HEAD )  https://github.com/solana-labs/rust.git" >> version.md
 
 git clone --single-branch --branch rust-1.54.0 https://github.com/rust-lang/cargo.git
@@ -32,19 +44,20 @@ popd
 # Copy rust build products
 mkdir -p deploy/rust
 cp version.md deploy/
-cp -R rust/build/${HOST_TRIPLE}/stage1/{bin,lib} deploy/rust/
-cp -R cargo/target/release/cargo deploy/rust/bin/
-rm -rf deploy/rust/lib/rustlib/src
+cp -R rust/build/${HOST_TRIPLE}/stage1/bin deploy/rust/
+mkdir -p deploy/rust/lib/rustlib/
+cp -R rust/build/${HOST_TRIPLE}/stage1/lib/rustlib/${HOST_TRIPLE} deploy/rust/lib/rustlib/
+cp -R rust/build/${HOST_TRIPLE}/stage1/lib/rustlib/bpfel-unknown-unknown deploy/rust/lib/rustlib/
+cp -R cargo/target/release/cargo${EXE_SUFFIX} deploy/rust/bin/
 
 # Copy llvm build products
 mkdir -p deploy/llvm/{bin,lib}
 while IFS= read -r f
 do
-    cp -R "rust/build/${HOST_TRIPLE}/llvm/build/bin/${f}" deploy/llvm/bin/
+    cp -R "rust/build/${HOST_TRIPLE}/llvm/build/bin/${f}${EXE_SUFFIX}" deploy/llvm/bin/
 done < <(cat <<EOF
 clang
 clang++
-clang-12
 clang-cl
 clang-cpp
 ld.lld


### PR DESCRIPTION
#### Problem

This repo doesn't produce llvm / rust executables for Windows.

#### Solution

Add a build job in GitHub referencing the future version 1.16 in the Rust repo, and also add support for building Windows in `build.sh`.

Important note: `clang-12` is not produced by the Windows build, so I removed it in the build artifacts produced.  Since `clang` is already at version 12, I thought this would be OK.  If you prefer, I can add a specific build step to copy `clang` to `clang-12` in Windows.

Also, because of a path being too long on Windows, the `copy` portion from `rust/build` has changed to specify the exact places to copy from.