### PR TITLE
Fix *nix binaries by copying all required objects

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -45,21 +45,26 @@ popd
 mkdir -p deploy/rust
 cp version.md deploy/
 cp -R rust/build/${HOST_TRIPLE}/stage1/bin deploy/rust/
+cp -R cargo/target/release/cargo"${EXE_SUFFIX}" deploy/rust/bin/
 mkdir -p deploy/rust/lib/rustlib/
 cp -R rust/build/${HOST_TRIPLE}/stage1/lib/rustlib/${HOST_TRIPLE} deploy/rust/lib/rustlib/
 cp -R rust/build/${HOST_TRIPLE}/stage1/lib/rustlib/bpfel-unknown-unknown deploy/rust/lib/rustlib/
-cp -R cargo/target/release/cargo"${EXE_SUFFIX}" deploy/rust/bin/
+find . -maxdepth 6 -type f -path "./rust/build/${HOST_TRIPLE}/stage1/lib/*" -exec cp {} deploy/rust/lib \;
 
 # Copy llvm build products
 mkdir -p deploy/llvm/{bin,lib}
 while IFS= read -r f
 do
-    cp -R "rust/build/${HOST_TRIPLE}/llvm/build/bin/${f}${EXE_SUFFIX}" deploy/llvm/bin/
+    bin_file="rust/build/${HOST_TRIPLE}/llvm/build/bin/${f}${EXE_SUFFIX}"
+    if [[ -f "$bin_file" ]] ; then
+        cp -R "$bin_file" deploy/llvm/bin/
+    fi
 done < <(cat <<EOF
 clang
 clang++
 clang-cl
 clang-cpp
+clang-12
 ld.lld
 ld64.lld
 llc
@@ -73,6 +78,36 @@ llvm-readobj
 EOF
          )
 cp -R rust/build/${HOST_TRIPLE}/llvm/build/lib/clang deploy/llvm/lib/
+
+# Check the Rust binaries
+while IFS= read -r f
+do
+    "./deploy/rust/bin/${f}${EXE_SUFFIX}" --version
+done < <(cat <<EOF
+cargo
+rustc
+rustdoc
+EOF
+         )
+# Check the LLVM binaries
+while IFS= read -r f
+do
+    "./deploy/llvm/bin/${f}${EXE_SUFFIX}" --version
+done < <(cat <<EOF
+clang
+clang++
+clang-cl
+clang-cpp
+ld.lld
+llc
+lld-link
+llvm-ar
+llvm-objcopy
+llvm-objdump
+llvm-readelf
+llvm-readobj
+EOF
+         )
 
 tar -C deploy -jcf ${ARTIFACT} .
 popd


### PR DESCRIPTION
The Windows work was a little overly aggressive in removing things that
did not seem needed, but are needed in *nix environments.  This adds
those parts back in, and additionally adds a step to check that all of
the binaries can correctly run with `--version`.