### PR TITLE
windows: Parametrize the build output dir to use more space

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
           ninja_sudo: sudo
           rust: stable
           tar: linux
+          out_dir: out
         - target: x86_64-apple-darwin
           os: macos-latest
           ninja_file: ninja-mac.zip
@@ -25,14 +26,16 @@ jobs:
           ninja_sudo: sudo
           rust: stable
           tar: osx
-        # - target: x86_64-pc-windows-msvc
-        #   os: windows-latest
-        #   ninja_file: ninja-win.zip
-        #   ninja_sha: bbde850d247d2737c5764c927d1071cbb1f1957dcabda4a130fa8547c12c695f
-        #   ninja_dir: /usr/bin
-        #   ninja_sudo:
-        #   rust: stable
-        #   tar: windows
+          out_dir: out
+        - target: x86_64-pc-windows-msvc
+          os: windows-latest
+          ninja_file: ninja-win.zip
+          ninja_sha: bbde850d247d2737c5764c927d1071cbb1f1957dcabda4a130fa8547c12c695f
+          ninja_dir: /usr/bin
+          ninja_sudo:
+          rust: stable
+          tar: windows
+          out_dir: D:\out
     steps:
     - uses: actions/checkout@v1
     - name: Install coreutils
@@ -52,13 +55,13 @@ jobs:
         rustup target add ${{ matrix.target }}
       shell: bash
     - name: Build
-      run: ./build.sh
+      run: ./build.sh ${{ matrix.out_dir }}
       shell: bash
     - name: Upload ${{ matrix.tar }} tarball
       uses: actions/upload-artifact@v2
       with:
         name: solana-bpf-tools-${{ matrix.tar }}.tar.bz2
-        path: out/solana-bpf-tools-${{ matrix.tar }}.tar.bz2
+        path: ${{ matrix.out_dir }}/solana-bpf-tools-${{ matrix.tar }}.tar.bz2
 
   release:
     name: Upload Release Assets
@@ -74,10 +77,10 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: solana-bpf-tools-osx.tar.bz2
-    # - name: Download Windows tarball
-    #   uses: actions/download-artifact@v2
-    #   with:
-    #     name: solana-bpf-tools-windows.tar.bz2
+    - name: Download Windows tarball
+      uses: actions/download-artifact@v2
+      with:
+        name: solana-bpf-tools-windows.tar.bz2
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1
@@ -108,13 +111,13 @@ jobs:
         asset_path: solana-bpf-tools-osx.tar.bz2
         asset_name: solana-bpf-tools-osx.tar.bz2
         asset_content_type: application/zip
-    # - name: Release Windows tarball
-    #   id: upload-release-windows
-    #   uses: actions/upload-release-asset@v1
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #   with:
-    #     upload_url: ${{ steps.create_release.outputs.upload_url }}
-    #     asset_path: solana-bpf-tools-windows.tar.bz2
-    #     asset_name: solana-bpf-tools-windows.tar.bz2
-    #     asset_content_type: application/zip
+    - name: Release Windows tarball
+      id: upload-release-windows
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: solana-bpf-tools-windows.tar.bz2
+        asset_name: solana-bpf-tools-windows.tar.bz2
+        asset_content_type: application/zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
           ninja_sudo:
           rust: stable
           tar: windows
-          out_dir: /d/out
+          out_dir: /c/out
     steps:
     - uses: actions/checkout@v1
     - name: Install coreutils

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
           ninja_sudo:
           rust: stable
           tar: windows
-          out_dir: D:\out
+          out_dir: /d/out
     steps:
     - uses: actions/checkout@v1
     - name: Install coreutils

--- a/build.sh
+++ b/build.sh
@@ -18,10 +18,11 @@ case "${unameOut}" in
 esac
 
 cd "$(dirname "$0")"
+OUT_DIR=${1:-out}
 
-rm -rf out
-mkdir -p out
-pushd out
+rm -rf "${OUT_DIR}"
+mkdir -p "${OUT_DIR}"
+pushd "${OUT_DIR}"
 
 git clone --single-branch --branch bpf-tools-v1.20 https://github.com/solana-labs/rust.git
 echo "$( cd rust && git rev-parse HEAD )  https://github.com/solana-labs/rust.git" >> version.md
@@ -43,10 +44,10 @@ if [[ "${HOST_TRIPLE}" != "x86_64-pc-windows-msvc" ]] ; then
     mkdir -p newlib_build
     mkdir -p newlib_install
     pushd newlib_build
-    CC="${GITHUB_WORKSPACE}/out/rust/build/${HOST_TRIPLE}/llvm/bin/clang" \
-      AR="${GITHUB_WORKSPACE}/out/rust/build/${HOST_TRIPLE}/llvm/bin/llvm-ar" \
-      RANLIB="${GITHUB_WORKSPACE}/out/rust/build/${HOST_TRIPLE}/llvm/bin/llvm-ranlib" \
-      ../newlib/newlib/configure --target=sbf-solana-solana --host=sbf-solana --build="${HOST_TRIPLE}" --prefix="${GITHUB_WORKSPACE}/out/newlib_install"
+    CC="${OUT_DIR}/rust/build/${HOST_TRIPLE}/llvm/bin/clang" \
+      AR="${OUT_DIR}/rust/build/${HOST_TRIPLE}/llvm/bin/llvm-ar" \
+      RANLIB="${OUT_DIR}/rust/build/${HOST_TRIPLE}/llvm/bin/llvm-ranlib" \
+      ../newlib/newlib/configure --target=sbf-solana-solana --host=sbf-solana --build="${HOST_TRIPLE}" --prefix="${OUT_DIR}/newlib_install"
     make install
     popd
 fi
@@ -130,8 +131,8 @@ popd
 if [[ "$(uname)" == "Darwin" ]] && [[ $# == 1 ]] && [[ "$1" == "--docker" ]] ; then
     docker system prune -a -f
     docker build -t solanalabs/bpf-tools .
-    id=$(docker create solanalabs/bpf-tools /build.sh)
+    id=$(docker create solanalabs/bpf-tools /build.sh "${OUT_DIR}")
     docker cp build.sh "${id}:/"
     docker start -a "${id}"
-    docker cp "${id}:out/solana-bpf-tools-linux.tar.bz2" out/
+    docker cp "${id}:${OUT_DIR}/solana-bpf-tools-linux.tar.bz2" "${OUT_DIR}"
 fi

--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ case "${unameOut}" in
 esac
 
 cd "$(dirname "$0")"
-OUT_DIR=${1:-out}
+OUT_DIR="$(readlink -f ${1:-out})"
 
 rm -rf "${OUT_DIR}"
 mkdir -p "${OUT_DIR}"

--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ case "${unameOut}" in
 esac
 
 cd "$(dirname "$0")"
-OUT_DIR=$(readlink -f "${1:-out}")
+OUT_DIR=$(realpath "${1:-out}")
 
 rm -rf "${OUT_DIR}"
 mkdir -p "${OUT_DIR}"

--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ case "${unameOut}" in
 esac
 
 cd "$(dirname "$0")"
-OUT_DIR="$(readlink -f ${1:-out})"
+OUT_DIR=$(readlink -f "${1:-out}")
 
 rm -rf "${OUT_DIR}"
 mkdir -p "${OUT_DIR}"


### PR DESCRIPTION
#### Problem

The windows build was turned off because of running out of disk space.

#### Solution

Apparently, the runners have more space in C:\ (edit: not D:\) on windows machines, so parametrize the output directory and do everything there.  We'll see if this works!