### PR TITLE
Deploy std source code

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -61,6 +61,9 @@ mkdir -p deploy/rust/lib/rustlib/
 cp -R "rust/build/${HOST_TRIPLE}/stage1/lib/rustlib/${HOST_TRIPLE}" deploy/rust/lib/rustlib/
 cp -R "rust/build/${HOST_TRIPLE}/stage1/lib/rustlib/bpfel-unknown-unknown" deploy/rust/lib/rustlib/
 find . -maxdepth 6 -type f -path "./rust/build/${HOST_TRIPLE}/stage1/lib/*" -exec cp {} deploy/rust/lib \;
+mkdir -p deploy/rust/lib/rustlib/src/rust
+cp "rust/build/${HOST_TRIPLE}/stage1/lib/rustlib/src/rust/Cargo.lock" deploy/rust/lib/rustlib/src/rust
+cp -R "rust/build/${HOST_TRIPLE}/stage1/lib/rustlib/src/rust/library" deploy/rust/lib/rustlib/src/rust
 
 # Copy llvm build products
 mkdir -p deploy/llvm/{bin,lib}


### PR DESCRIPTION
Deploy the equivalent of the rust-src rustup component. Needed for `cargo build -Z build-std` to work.