### PR TITLE
Add check for alternate `uname -m` output for arm arch

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ unameOut="$(uname -s)"
 case "${unameOut}" in
     Darwin*)
         EXE_SUFFIX=
-        if [[ "$(uname -m)" == "arm64" ]] ; then
+        if [[ "$(uname -m)" == "arm64" ]] || [[ "$(uname -m)" == "aarch64" ]]; then
             HOST_TRIPLE=aarch64-apple-darwin
             ARTIFACT=platform-tools-osx-aarch64.tar.bz2
         else
@@ -18,7 +18,7 @@ case "${unameOut}" in
         ARTIFACT=platform-tools-windows-x86_64.tar.bz2;;
     Linux* | *)
         EXE_SUFFIX=
-        if [[ "$(uname -m)" == "arm64" ]] ; then
+        if [[ "$(uname -m)" == "arm64" ]] || [[ "$(uname -m)" == "aarch64" ]]; then
             HOST_TRIPLE=aarch64-unknown-linux-gnu
             ARTIFACT=platform-tools-linux-aarch64.tar.bz2
         else


### PR DESCRIPTION
Some machines will output `aarch64` instead of `arm64`, this pr adds support for both.

After:

- Running the build script (fails on missing python dir [here](https://github.com/solana-labs/platform-tools/blob/master/build.sh#L120), never figured this out though) 
- Copying files into `~/.cache/solana/v1.x/platform-tools`
- Symlinking to `$sbf_sdk_dir/dependencies`

I am able to successfully run cargo build with `aarch64-unknown-linux-gnu` 

```sh
root@822384e32597:/tmp/decoy-crate# cargo build-sbf
    Finished release [optimized] target(s) in 1.32s
root@822384e32597:/tmp/decoy-crate# cargo build-bpf
    Finished release [optimized] target(s) in 1.30s
root@822384e32597:/tmp/decoy-crate# uname -m
aarch64
```


The build time for this was very long on my machine so it would be amazing to have this in releases (current issue https://github.com/solana-labs/platform-tools/issues/66)