### PR TITLE
Lock rust version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,9 @@ jobs:
         ${{ matrix.ninja_sudo }} unzip ${{ matrix.ninja_file }} -d ${{ matrix.ninja_dir }} && rm ${{ matrix.ninja_file }}
       shell: bash
     - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: 1.79.0
     - name: Build
       run: ./build.sh ${{ matrix.out_dir }}
       shell: bash


### PR DESCRIPTION
We cannot build Cargo 1.75.0 with the newest Rust version, hindering the platform tools release.