### PR TITLE
Bump clang version

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -96,7 +96,7 @@ clang
 clang++
 clang-cl
 clang-cpp
-clang-17
+clang-18
 ld.lld
 ld64.lld
 llc


### PR DESCRIPTION
The Rust upgrade also brought clang 18.