### PR TITLE
Bump download artifact action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,27 +106,27 @@ jobs:
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     steps:
     - name: Download Linux tarball
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: platform-tools-linux-x86_64.tar.bz2
     - name: Download Linux move-dev
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: move-dev-linux-x86_64.tar.bz2
     - name: Download macOS tarball
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: platform-tools-osx-aarch64.tar.bz2
     - name: Download macOS move-dev
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: move-dev-osx-aarch64.tar.bz2
     - name: Download Windows tarball
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: platform-tools-windows-x86_64.tar.bz2
     - name: Download Windows move-dev
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: move-dev-windows-x86_64.tar.bz2
     - name: Create Release


### PR DESCRIPTION
The GitHub actions for download-artifact v3 is deprecated.