### PR TITLE
Bump platform tools versions

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -75,6 +75,8 @@ pushd rust
 if [[ "${HOST_TRIPLE}" == "x86_64-pc-windows-msvc" ]] ; then
     # Do not build lldb on Windows
     sed -i -e 's#enable-projects = \"clang;lld;lldb\"#enable-projects = \"clang;lld\"#g' config.toml
+    # Do not optimize for size on Windows
+    sed -i -e 's#optimize = \"s\"#optimize = true#g' config.toml
 fi
 ./build.sh
 popd

--- a/build.sh
+++ b/build.sh
@@ -65,10 +65,10 @@ rm -rf "${OUT_DIR}"
 mkdir -p "${OUT_DIR}"
 pushd "${OUT_DIR}"
 
-git clone --single-branch --branch solana-tools-v1.44 --recurse-submodules --shallow-submodules https://github.com/anza-xyz/rust.git
+git clone --single-branch --branch solana-tools-v1.45 --recurse-submodules --shallow-submodules https://github.com/anza-xyz/rust.git
 echo "$( cd rust && git rev-parse HEAD )  https://github.com/anza-xyz/rust.git" >> version.md
 
-git clone --single-branch --branch solana-tools-v1.44 https://github.com/anza-xyz/cargo.git
+git clone --single-branch --branch solana-tools-v1.45 https://github.com/anza-xyz/cargo.git
 echo "$( cd cargo && git rev-parse HEAD )  https://github.com/anza-xyz/cargo.git" >> version.md
 
 pushd rust
@@ -88,7 +88,7 @@ fi
 popd
 
 if [[ "${HOST_TRIPLE}" != "x86_64-pc-windows-msvc" ]] ; then
-    git clone --single-branch --branch solana-tools-v1.44 https://github.com/anza-xyz/newlib.git
+    git clone --single-branch --branch solana-tools-v1.45 https://github.com/anza-xyz/newlib.git
     echo "$( cd newlib && git rev-parse HEAD )  https://github.com/anza-xyz/newlib.git" >> version.md
 
     build_newlib "v0"


### PR DESCRIPTION
The new release fixes a regression with `cargo-build-sbf` and reduces code size for SBPFv2 and SBPFv3.

The code size reduction doesn't work on windows (see the comment below).