### PR TITLE
Bump tools to v1.46

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,11 +93,6 @@ jobs:
       with:
         name: platform-tools-${{ matrix.tar }}-${{ matrix.arch }}.tar.bz2
         path: platform-tools-${{ matrix.tar }}-${{ matrix.arch }}.tar.bz2
-    - name: Upload move-dev ${{ matrix.tar }} tarball
-      uses: actions/upload-artifact@v4
-      with:
-        name: move-dev-${{ matrix.tar }}-${{ matrix.arch }}.tar.bz2
-        path: move-dev-${{ matrix.tar }}-${{ matrix.arch }}.tar.bz2
 
   release:
     name: Upload Release Assets

--- a/build.sh
+++ b/build.sh
@@ -65,10 +65,10 @@ rm -rf "${OUT_DIR}"
 mkdir -p "${OUT_DIR}"
 pushd "${OUT_DIR}"
 
-git clone --single-branch --branch solana-tools-v1.45 --recurse-submodules --shallow-submodules https://github.com/anza-xyz/rust.git
+git clone --single-branch --branch solana-tools-v1.46 --recurse-submodules --shallow-submodules https://github.com/anza-xyz/rust.git
 echo "$( cd rust && git rev-parse HEAD )  https://github.com/anza-xyz/rust.git" >> version.md
 
-git clone --single-branch --branch solana-tools-v1.45 https://github.com/anza-xyz/cargo.git
+git clone --single-branch --branch solana-tools-v1.46 https://github.com/anza-xyz/cargo.git
 echo "$( cd cargo && git rev-parse HEAD )  https://github.com/anza-xyz/cargo.git" >> version.md
 
 pushd rust
@@ -90,7 +90,7 @@ fi
 popd
 
 if [[ "${HOST_TRIPLE}" != "x86_64-pc-windows-msvc" ]] ; then
-    git clone --single-branch --branch solana-tools-v1.45 https://github.com/anza-xyz/newlib.git
+    git clone --single-branch --branch solana-tools-v1.46 https://github.com/anza-xyz/newlib.git
     echo "$( cd newlib && git rev-parse HEAD )  https://github.com/anza-xyz/newlib.git" >> version.md
 
     build_newlib "v0"


### PR DESCRIPTION
The new version brings a bug fix to Rust 1.79.0.


PS: I also removed the upload of Move objects, since we don't support it anymore.