### PR TITLE
Bump version to 1.47 (Rust 1.84.1)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: 1.79.0
+        toolchain: 1.84.1
     - name: Build
       run: ./build.sh ${{ matrix.out_dir }}
       shell: bash

--- a/build.sh
+++ b/build.sh
@@ -199,19 +199,9 @@ EOF
 tar -C deploy -jcf ${ARTIFACT} .
 rm -rf deploy
 
-# Package LLVM binaries for Move project
-MOVE_DEV_TAR=${ARTIFACT/platform-tools/move-dev}
-mkdir move-dev
-if [[ "${HOST_TRIPLE}" == "x86_64-pc-windows-msvc" ]] ; then
-    rm -f rust/build/${HOST_TRIPLE}/llvm/bin/{llvm-ranlib.exe,llvm-lib.exe,llvm-dlltool.exe}
-fi
-mv "rust/build/${HOST_TRIPLE}/llvm/"{bin,include,lib} move-dev/
-tar -jcf "${MOVE_DEV_TAR}" move-dev
-
 popd
 
 mv "${OUT_DIR}/${ARTIFACT}" .
-mv "${OUT_DIR}/${MOVE_DEV_TAR}" .
 
 # Build linux binaries on macOS in docker
 if [[ "$(uname)" == "Darwin" ]] && [[ $# == 1 ]] && [[ "$1" == "--docker" ]] ; then

--- a/build.sh
+++ b/build.sh
@@ -65,10 +65,10 @@ rm -rf "${OUT_DIR}"
 mkdir -p "${OUT_DIR}"
 pushd "${OUT_DIR}"
 
-git clone --single-branch --branch solana-tools-v1.46 --recurse-submodules --shallow-submodules https://github.com/anza-xyz/rust.git
+git clone --single-branch --branch solana-tools-v1.47 --recurse-submodules --shallow-submodules https://github.com/anza-xyz/rust.git
 echo "$( cd rust && git rev-parse HEAD )  https://github.com/anza-xyz/rust.git" >> version.md
 
-git clone --single-branch --branch solana-tools-v1.46 https://github.com/anza-xyz/cargo.git
+git clone --single-branch --branch solana-tools-v1.47 https://github.com/anza-xyz/cargo.git
 echo "$( cd cargo && git rev-parse HEAD )  https://github.com/anza-xyz/cargo.git" >> version.md
 
 pushd rust
@@ -90,7 +90,7 @@ fi
 popd
 
 if [[ "${HOST_TRIPLE}" != "x86_64-pc-windows-msvc" ]] ; then
-    git clone --single-branch --branch solana-tools-v1.46 https://github.com/anza-xyz/newlib.git
+    git clone --single-branch --branch solana-tools-v1.47 https://github.com/anza-xyz/newlib.git
     echo "$( cd newlib && git rev-parse HEAD )  https://github.com/anza-xyz/newlib.git" >> version.md
 
     build_newlib "v0"
@@ -129,7 +129,7 @@ clang
 clang++
 clang-cl
 clang-cpp
-clang-18
+clang-19
 ld.lld
 ld64.lld
 llc


### PR DESCRIPTION
This PR bumps the platform tools version to 1.47, which will bring Rust 1.84.1.

I also removed the creation of Move files, since move is not supported anymore.