### PR TITLE
Bump version to v1.52

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,7 +89,7 @@ jobs:
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: 1.84.1
+        toolchain: 1.89.0
     - name: Build
       run: ./build.sh ${{ matrix.out_dir }}
       shell: bash

--- a/build.sh
+++ b/build.sh
@@ -159,7 +159,7 @@ if [[ "${HOST_TRIPLE}" != "x86_64-pc-windows-msvc" ]] ; then
     cp -R rust/src/llvm-project/lldb/scripts/solana/* deploy/llvm/bin/
     cp -R rust/build/${HOST_TRIPLE}/llvm/lib/liblldb.* deploy/llvm/lib/
     if [[ "${HOST_TRIPLE}" == "x86_64-unknown-linux-gnu" || "${HOST_TRIPLE}" == "aarch64-unknown-linux-gnu" ]]; then
-        cp -r rust/build/${HOST_TRIPLE}/llvm/local/lib/python* deploy/llvm/lib
+        cp -R rust/build/${HOST_TRIPLE}/llvm/local/lib/python* deploy/llvm/lib
     else
         cp -R rust/build/${HOST_TRIPLE}/llvm/lib/python* deploy/llvm/lib/
     fi

--- a/build.sh
+++ b/build.sh
@@ -76,6 +76,11 @@ if [[ "${HOST_TRIPLE}" == "x86_64-pc-windows-msvc" ]] ; then
     # Do not build lldb on Windows
     sed -i -e 's#enable-projects = \"clang;lld;lldb\"#enable-projects = \"clang;lld\"#g' bootstrap.toml
 fi
+
+if [[ "${HOST_TRIPLE}" == *"apple"* ]]; then
+    ./src/llvm-project/lldb/scripts/macos-setup-codesign.sh
+fi
+
 ./build.sh
 popd
 

--- a/build.sh
+++ b/build.sh
@@ -74,9 +74,7 @@ echo "$( cd cargo && git rev-parse HEAD )  https://github.com/anza-xyz/cargo.git
 pushd rust
 if [[ "${HOST_TRIPLE}" == "x86_64-pc-windows-msvc" ]] ; then
     # Do not build lldb on Windows
-    sed -i -e 's#enable-projects = \"clang;lld;lldb\"#enable-projects = \"clang;lld\"#g' config.toml
-    # Do not optimize for size on Windows
-    sed -i -e 's#optimize = \"s\"#optimize = true#g' config.toml
+    sed -i -e 's#enable-projects = \"clang;lld;lldb\"#enable-projects = \"clang;lld\"#g' bootstrap.toml
 fi
 ./build.sh
 popd

--- a/build.sh
+++ b/build.sh
@@ -65,10 +65,10 @@ rm -rf "${OUT_DIR}"
 mkdir -p "${OUT_DIR}"
 pushd "${OUT_DIR}"
 
-git clone --single-branch --branch solana-tools-v1.51 --recurse-submodules --shallow-submodules https://github.com/anza-xyz/rust.git
+git clone --single-branch --branch solana-tools-v1.52 --recurse-submodules --shallow-submodules https://github.com/anza-xyz/rust.git
 echo "$( cd rust && git rev-parse HEAD )  https://github.com/anza-xyz/rust.git" >> version.md
 
-git clone --single-branch --branch solana-tools-v1.51 https://github.com/anza-xyz/cargo.git
+git clone --single-branch --branch solana-tools-v1.52 https://github.com/anza-xyz/cargo.git
 echo "$( cd cargo && git rev-parse HEAD )  https://github.com/anza-xyz/cargo.git" >> version.md
 
 pushd rust
@@ -90,7 +90,7 @@ fi
 popd
 
 if [[ "${HOST_TRIPLE}" != "x86_64-pc-windows-msvc" ]] ; then
-    git clone --single-branch --branch solana-tools-v1.51 https://github.com/anza-xyz/newlib.git
+    git clone --single-branch --branch solana-tools-v1.52 https://github.com/anza-xyz/newlib.git
     echo "$( cd newlib && git rev-parse HEAD )  https://github.com/anza-xyz/newlib.git" >> version.md
 
     build_newlib "v0"

--- a/build.sh
+++ b/build.sh
@@ -99,8 +99,6 @@ if [[ "${HOST_TRIPLE}" != "x86_64-pc-windows-msvc" ]] ; then
     build_newlib "v0"
     build_newlib "v1"
     build_newlib "v2"
-    build_newlib "v3"
-    build_newlib "v4"
 fi
 
 # Copy rust build products
@@ -114,8 +112,6 @@ cp -R "rust/build/${HOST_TRIPLE}/stage1/lib/rustlib/sbf-solana-solana" deploy/ru
 cp -R "rust/build/${HOST_TRIPLE}/stage1/lib/rustlib/sbpf-solana-solana" deploy/rust/lib/rustlib/
 cp -R "rust/build/${HOST_TRIPLE}/stage1/lib/rustlib/sbpfv1-solana-solana" deploy/rust/lib/rustlib/
 cp -R "rust/build/${HOST_TRIPLE}/stage1/lib/rustlib/sbpfv2-solana-solana" deploy/rust/lib/rustlib/
-cp -R "rust/build/${HOST_TRIPLE}/stage1/lib/rustlib/sbpfv3-solana-solana" deploy/rust/lib/rustlib/
-cp -R "rust/build/${HOST_TRIPLE}/stage1/lib/rustlib/sbpfv4-solana-solana" deploy/rust/lib/rustlib/
 find . -maxdepth 6 -type f -path "./rust/build/${HOST_TRIPLE}/stage1/lib/*" -exec cp {} deploy/rust/lib \;
 mkdir -p deploy/rust/lib/rustlib/src/rust
 cp "rust/build/${HOST_TRIPLE}/stage1/lib/rustlib/src/rust/Cargo.lock" deploy/rust/lib/rustlib/src/rust
@@ -157,7 +153,6 @@ if [[ "${HOST_TRIPLE}" != "x86_64-pc-windows-msvc" ]] ; then
     copy_newlib "v0"
     copy_newlib "v1"
     copy_newlib "v2"
-    copy_newlib "v3"
 
     cp -R rust/src/llvm-project/lldb/scripts/solana/* deploy/llvm/bin/
     cp -R rust/build/${HOST_TRIPLE}/llvm/lib/liblldb.* deploy/llvm/lib/


### PR DESCRIPTION
v1.52 brings Rust 1.89.0.

**Changes**

1. Bump tagged version to v1.52.
2. MacOS now requires code signing for the lldb debugger.
3. Removed SBPF v3 and v4 to save space in the release tarball.