### PR TITLE
Bump clang version

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -130,7 +130,7 @@ clang
 clang++
 clang-cl
 clang-cpp
-clang-19
+clang-20
 ld.lld
 ld64.lld
 llc


### PR DESCRIPTION
Clang was updated to version 20 together with Rust 1.89.0