### PR TITLE
Use macos 26 for intel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
           out_dir: out
         - target: x86_64-apple-darwin
           arch: x86_64
-          os: macos-15-intel
+          os: macos-26-intel
           ninja_file: ninja-mac.zip
           ninja_dir: /usr/local/bin
           ninja_sudo: sudo


### PR DESCRIPTION
Github just made available MacOS 26 runners with Intel CPUs.


PS: Apple just released a note to developers saying that it is safe to drop support for Intel Macs, maybe we can just get rid of this for the next releases.